### PR TITLE
Don't add limit to params array if no valid limit is set.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ class CqlBuilder {
 
   limit(limit) {
     this.exps.limit = limit > 0;
-    this.vals.limit = limit;
+    this.vals.limit = this.exps.limit ? limit : 0;
     return this;
   }
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -89,6 +89,8 @@ describe('select', () => {
     expect(result1.query).toBe('SELECT * FROM test_table');
     expect(result2.query).toBe('SELECT * FROM test_table');
     expect(result3.query).toBe('SELECT * FROM test_table LIMIT ?');
+    expect(result1.params).toHaveLength(0);
+    expect(result2.params).toHaveLength(0);
     expect(result3.params).toEqual([50]);
   });
   test('with order', () => {


### PR DESCRIPTION
When an invalid limit is set with .limit(<0), then when the params
are built, a non-falsy (i.e., non-zero) limit is seen and is added
to the params array.

Added code to update the value based on the validity of the limit arg.
Added tests to cover this case.

Thanks for a great, clean query builder library. This is very helpful.
-david