### PR TITLE
Add ALLOW FILTERING via new filtering() method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridi/cql-builder",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Cassandra CQL Builder",
   "main": "dist/index.js",
   "directories": {

--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,8 @@ const COMMANDS = Object.freeze({
   },
   select: {
     name: 'SELECT',
-    query: context => `SELECT ${context.field} FROM ${context.table} ${context.where} ${context.order} ${context.limit}`,
-    using: ['field', 'table', 'where', 'order', 'limit'],
+    query: context => `SELECT ${context.field} FROM ${context.table} ${context.where} ${context.order} ${context.limit} ${context.filtering}`,
+    using: ['field', 'table', 'where', 'order', 'limit', 'filtering'],
   },
   update: {
     name: 'UPDATE',
@@ -39,6 +39,7 @@ const EXPRESSIONS = Object.freeze({
   set: exp => `${exp.set.map(field => `${field} = ?`).join(', ')}`,
   option: exp => `${exp.option.length === 0 ? '' : `USING ${exp.option.map(option => `${option} ?`).join(' AND ')}`}`,
   condition: exp => `${exp.upsert ? '' : 'IF EXISTS'}`,
+  filtering: exp => `${exp.filtering ? 'ALLOW FILTERING' : ''}`,
 });
 
 class CqlBuilderError extends Error {
@@ -110,6 +111,11 @@ class CqlBuilder {
     return this;
   }
 
+  filtering(filter=true) {
+    this.exps.filtering = filter;
+    return this;
+  }
+
   clear() {
     this.exps = {
       keyspace: null,
@@ -122,6 +128,7 @@ class CqlBuilder {
       option: [],
       set: [],
       upsert: false,
+      filtering: false,
     };
     this.vals = {
       where: [],

--- a/tests/test.js
+++ b/tests/test.js
@@ -101,6 +101,12 @@ describe('select', () => {
     const result1 = Select().table('test_table', 'test_keyspace').field('COUNT(*)').build();
     expect(result1.query).toBe('SELECT COUNT(*) FROM test_keyspace.test_table');
   });
+  test('with filtering', () => {
+    const result1 = Select().table('test_table').filtering().build();
+    const result2 = Select().table('test_table').filtering().filtering(false).build();
+    expect(result1.query).toBe('SELECT * FROM test_table ALLOW FILTERING');
+    expect(result2.query).toBe('SELECT * FROM test_table');
+  });
   test('with all', () => {
     const result1 = Select()
       .table('test_table', 'test_keyspace')
@@ -111,6 +117,7 @@ describe('select', () => {
       .where('key3 IN (?, ?)', 3000, 4000)
       .limit(5000)
       .order('key1 DESC')
+      .filtering()
       .build();
     const result2 = Select()
       .table('test_table', 'test_keyspace')
@@ -126,8 +133,9 @@ describe('select', () => {
       .set('column3', 'c')
       .set('column4', 'd')
       .option('TTL', 86400)
+      .filtering()
       .build();
-    expect(result1.query).toBe('SELECT column1, column2, column3 FROM test_keyspace.test_table WHERE key1 = ? AND key2 > ? AND key3 IN (?, ?) ORDER BY key1 DESC LIMIT ?');
+    expect(result1.query).toBe('SELECT column1, column2, column3 FROM test_keyspace.test_table WHERE key1 = ? AND key2 > ? AND key3 IN (?, ?) ORDER BY key1 DESC LIMIT ? ALLOW FILTERING');
     expect(result2.query).toBe(result1.query);
     expect(result1.params).toEqual([1000, 2000, 3000, 4000, 5000]);
     expect(result2.params).toEqual(result1.params);


### PR DESCRIPTION
Though not recommended, CQL allows for filtering select results when
doing SELECT queries and gets all results then post filters the query results.

1. Added new filtering() method
2. Updated COMMANDS and EXPRESSIONS to support
3. Added 'with filtering' Select test
4. Extended 'with all' Select test to add filtering() calls